### PR TITLE
Fix favicon path

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
   <link rel="icon" href="/favicons/favicon.ico">
   <link rel="apple-touch-icon" sizes="120x120" href="/favicons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favivons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
 
   <link rel="preconnect" href="https://fonts.gstatic.com">

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <link rel="icon" href="<%= BASE_URL %>favicons/favicon.ico">
   <link rel="apple-touch-icon" sizes="120x120" href="<%= BASE_URL %>/favicons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="<%= BASE_URL %>/favivons/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="<%= BASE_URL %>/favicons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="<%= BASE_URL %>/favicons/favicon-16x16.png">
 
   <title>


### PR DESCRIPTION
## Summary
- fix 32x32 favicon path typo in `index.html` and `src/assets/index.html`

## Testing
- `npm run lint` *(fails: invalid option)*
- `npm run build-only`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6881ace505c4832eafc4ce018e610681