### PR TITLE
Fix resetProgress when playback item missing

### DIFF
--- a/src/stores/spotify.ts
+++ b/src/stores/spotify.ts
@@ -118,10 +118,12 @@ export const useSpotifyStore = defineStore(
     }*/
 
     function resetProgress() {
-      if (playbackState.value) {
-        progressDuration.value = playbackState.value.item.duration_ms ?? 1
-        progressPosition.value = playbackState.value.progress_ms ?? 1
+      if (!playbackState.value?.item) {
+        return
       }
+
+      progressDuration.value = playbackState.value.item?.duration_ms ?? 1
+      progressPosition.value = playbackState.value.progress_ms ?? 1
     }
 
     function updateProgress(startTime: number) {


### PR DESCRIPTION
## Summary
- fix `resetProgress` to safely read playback state

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881acea4c50832eabfb28c77dbe07fd