### PR TITLE
Fix PlayThing spelling in AuthoriseView

### DIFF
--- a/src/views/AuthoriseView.vue
+++ b/src/views/AuthoriseView.vue
@@ -3,7 +3,7 @@
     <h1 class="authorise__heading">PlayThing</h1>
 
     <p class="authorise__copy">
-      PlaThing is a simple Spotify 'Now Playing' screen designed for the
+      PlayThing is a simple Spotify 'Now Playing' screen designed for the
       Raspberry Pi. Login with Spotify below and start playing some music!
     </p>
 


### PR DESCRIPTION
## Summary
- correct 'PlaThing' to 'PlayThing' in the authorisation intro

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881ace85728832e9a6fe22fc5464ea9