### PR TITLE
Remove unused playback scopes

### DIFF
--- a/src/stores/spotify.ts
+++ b/src/stores/spotify.ts
@@ -10,11 +10,9 @@ const scopes = [
   'user-read-playback-state',
   'user-read-recently-played',
   'user-library-read',
-  'streaming',
   'user-read-private',
   'user-read-birthdate',
-  'user-read-email',
-  'web-playback'
+  'user-read-email'
 ]
 
 export const useSpotifyStore = defineStore(


### PR DESCRIPTION
## Summary
- delete unused `streaming` and `web-playback` scopes in the Spotify store

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881aaf591e4832eb5bd4748ca83dc2f