### PR TITLE
Fix album art positioning and dynamic scaling

### DIFF
--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -79,8 +79,7 @@ const { lineNumber, lineNumberArtist, hideControls } = storeToRefs(appStore)
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    flex: 1;
-    min-width: 0;
+    width: 38.02083333333333vw;
   }
 
   &__details > div:first-child {
@@ -136,13 +135,14 @@ const { lineNumber, lineNumberArtist, hideControls } = storeToRefs(appStore)
 }
 
 .container {
-  display: flex;
-  gap: 3vw;
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 5vh 5vw;
-  align-items: center;
+  display: grid;
+  gap: 5.729166666666666vw;
+  grid-template-columns: repeat(2, 1fr);
+  position: absolute;
+  top: 20.37037037037037vh;
+  left: 11.458333333333332vw;
+  width: 77.08333333333334vw;
+  height: 61.111111111111114vh;
 }
 
 .multiline-ellipsis {

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -47,6 +47,7 @@ export const useAppStore = defineStore(
       let textSize = ''
       let titleSize = ''
       let artistSize = ''
+      let albumArtSize = ''
 
       if (value === 'none') {
         displayText = 'none'
@@ -54,6 +55,7 @@ export const useAppStore = defineStore(
         textSize = '1rem'
         titleSize = ''
         artistSize = ''
+        albumArtSize = 'clamp(200px, 45vmin, 640px)'
       } else if (value === 'small') {
         displayText = 'inherit'
         displayAlbumArt = 'inherit'
@@ -62,6 +64,7 @@ export const useAppStore = defineStore(
         artistSize = '50px'
         lineNumber.value = 4
         lineNumberArtist.value = 3
+        albumArtSize = 'clamp(150px, 40vmin, 640px)'
       } else if (value === 'medium') {
         displayText = 'inherit'
         displayAlbumArt = 'inherit'
@@ -74,6 +77,7 @@ export const useAppStore = defineStore(
           lineNumber.value = 3
         }
         lineNumberArtist.value = 3
+        albumArtSize = 'clamp(150px, 38vmin, 640px)'
       } else if (value === 'large') {
         displayText = 'inherit'
         displayAlbumArt = 'inherit'
@@ -81,6 +85,7 @@ export const useAppStore = defineStore(
         titleSize = '110px'
         artistSize = '50px'
         lineNumberArtist.value = 2
+        albumArtSize = 'clamp(150px, 35vmin, 640px)'
         if (hideControls.value) {
           lineNumber.value = 4
         } else {
@@ -93,6 +98,7 @@ export const useAppStore = defineStore(
         titleSize = '130px'
         artistSize = '50px'
         lineNumberArtist.value = 1
+        albumArtSize = 'clamp(150px, 32vmin, 640px)'
         if (hideControls.value) {
           lineNumber.value = 3
         } else {
@@ -104,6 +110,7 @@ export const useAppStore = defineStore(
         displayAlbumArt = 'none'
         titleSize = ''
         artistSize = ''
+        albumArtSize = 'clamp(150px, 40vmin, 640px)'
       }
 
       document.documentElement.style.setProperty('--display-text', displayText)
@@ -111,6 +118,7 @@ export const useAppStore = defineStore(
       document.documentElement.style.setProperty('--text-size', textSize)
       document.documentElement.style.setProperty('--track-text-size', titleSize)
       document.documentElement.style.setProperty('--artist-text-size', artistSize)
+      document.documentElement.style.setProperty('--album-art-size', albumArtSize)
     }
 
     function onKeyDown(event: KeyboardEvent) {


### PR DESCRIPTION
## Summary
- restore previous grid layout for RegularPlayer and keep album art centering
- adjust album art size according to selected text scale

## Testing
- `npx eslint -c .eslintrc.cjs . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix`
- `npm run format`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6881b9b5d638832eacb195693671c09b