### PR TITLE
Keep album-art size fixed and overlay progress bar

### DIFF
--- a/src/components/AlbumArt.vue
+++ b/src/components/AlbumArt.vue
@@ -1,38 +1,22 @@
 <template>
   <div class="now-playing__image">
     <transition name="fade">
-      <img
-        :key="albumArtURL"
-        :src="albumArtURL"
-        :style="`margin-bottom: ${
-          miscellaneousOption.includes('show-progress-bar') ? '15px' : '0px'
-        }`"
-      />
+      <img :key="albumArtURL" :src="albumArtURL" />
     </transition>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { useSettingsStore } from '@/stores/settings'
 import { storeToRefs } from 'pinia'
 import { useSpotifyStore } from '@/stores/spotify'
 
 const spotifyStore = useSpotifyStore()
 
-const settingsStore = useSettingsStore()
 const { albumArtURL } = storeToRefs(spotifyStore)
-const { miscellaneousOption } = storeToRefs(settingsStore)
 </script>
 
 <style lang="scss" scoped>
 .now-playing {
-  &__cover {
-    position: relative;
-    width: var(--album-art-size);
-    max-width: 95vmin;
-    display: block;
-  }
-
   &__image {
     //box-shadow: 1px 1px 16px -2px rgba(0, 0, 0, 0.3);
     height: auto;

--- a/src/components/NoTextPlayer.vue
+++ b/src/components/NoTextPlayer.vue
@@ -109,6 +109,7 @@ const { hideControls } = storeToRefs(appStore)
     gap: 1vh;
     align-items: center;
     width: var(--album-art-size);
+    position: relative;
   }
 
   &__track {

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -15,7 +15,9 @@ const { progressPercentage } = storeToRefs(spotifyStore)
 
 <style lang="scss" progress>
 .progress-container {
-  position: relative;
+  position: absolute;
+  bottom: 0;
+  left: 0;
   width: 100%;
   border-radius: 5px;
   overflow: hidden;

--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -64,6 +64,7 @@ const { lineNumber, lineNumberArtist, hideControls } = storeToRefs(appStore)
   &__cover {
     width: var(--album-art-size);
     max-width: 95vmin;
+    position: relative;
   }
 
   &__image {

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -47,15 +47,12 @@ export const useAppStore = defineStore(
       let textSize = ''
       let titleSize = ''
       let artistSize = ''
-      let albumArtSize = ''
-
       if (value === 'none') {
         displayText = 'none'
         displayAlbumArt = 'inherit'
         textSize = '1rem'
         titleSize = ''
         artistSize = ''
-        albumArtSize = 'clamp(200px, 45vmin, 640px)'
       } else if (value === 'small') {
         displayText = 'inherit'
         displayAlbumArt = 'inherit'
@@ -64,7 +61,6 @@ export const useAppStore = defineStore(
         artistSize = '50px'
         lineNumber.value = 4
         lineNumberArtist.value = 3
-        albumArtSize = 'clamp(150px, 40vmin, 640px)'
       } else if (value === 'medium') {
         displayText = 'inherit'
         displayAlbumArt = 'inherit'
@@ -77,7 +73,6 @@ export const useAppStore = defineStore(
           lineNumber.value = 3
         }
         lineNumberArtist.value = 3
-        albumArtSize = 'clamp(150px, 38vmin, 640px)'
       } else if (value === 'large') {
         displayText = 'inherit'
         displayAlbumArt = 'inherit'
@@ -85,7 +80,6 @@ export const useAppStore = defineStore(
         titleSize = '110px'
         artistSize = '50px'
         lineNumberArtist.value = 2
-        albumArtSize = 'clamp(150px, 35vmin, 640px)'
         if (hideControls.value) {
           lineNumber.value = 4
         } else {
@@ -98,7 +92,6 @@ export const useAppStore = defineStore(
         titleSize = '130px'
         artistSize = '50px'
         lineNumberArtist.value = 1
-        albumArtSize = 'clamp(150px, 32vmin, 640px)'
         if (hideControls.value) {
           lineNumber.value = 3
         } else {
@@ -110,7 +103,6 @@ export const useAppStore = defineStore(
         displayAlbumArt = 'none'
         titleSize = ''
         artistSize = ''
-        albumArtSize = 'clamp(150px, 40vmin, 640px)'
       }
 
       document.documentElement.style.setProperty('--display-text', displayText)
@@ -118,7 +110,6 @@ export const useAppStore = defineStore(
       document.documentElement.style.setProperty('--text-size', textSize)
       document.documentElement.style.setProperty('--track-text-size', titleSize)
       document.documentElement.style.setProperty('--artist-text-size', artistSize)
-      document.documentElement.style.setProperty('--album-art-size', albumArtSize)
     }
 
     function onKeyDown(event: KeyboardEvent) {


### PR DESCRIPTION
## Summary
- keep `--album-art-size` constant by removing updates in the app store
- set album art containers to relative positioning
- absolutely position the progress bar
- drop unused album art styles

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run build` *(fails: run-p: not found)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6881bdf75100832eae0b426c277c7236