### PR TITLE
Revert album art sizing changes

### DIFF
--- a/src/components/AlbumArt.vue
+++ b/src/components/AlbumArt.vue
@@ -1,22 +1,38 @@
 <template>
   <div class="now-playing__image">
     <transition name="fade">
-      <img :key="albumArtURL" :src="albumArtURL" />
+      <img
+        :key="albumArtURL"
+        :src="albumArtURL"
+        :style="`margin-bottom: ${
+          miscellaneousOption.includes('show-progress-bar') ? '15px' : '0px'
+        }`"
+      />
     </transition>
   </div>
 </template>
 
 <script lang="ts" setup>
+import { useSettingsStore } from '@/stores/settings'
 import { storeToRefs } from 'pinia'
 import { useSpotifyStore } from '@/stores/spotify'
 
 const spotifyStore = useSpotifyStore()
 
+const settingsStore = useSettingsStore()
 const { albumArtURL } = storeToRefs(spotifyStore)
+const { miscellaneousOption } = storeToRefs(settingsStore)
 </script>
 
 <style lang="scss" scoped>
 .now-playing {
+  &__cover {
+    position: relative;
+    width: var(--album-art-size);
+    max-width: 95vmin;
+    display: block;
+  }
+
   &__image {
     //box-shadow: 1px 1px 16px -2px rgba(0, 0, 0, 0.3);
     height: auto;

--- a/src/components/NoTextPlayer.vue
+++ b/src/components/NoTextPlayer.vue
@@ -109,7 +109,6 @@ const { hideControls } = storeToRefs(appStore)
     gap: 1vh;
     align-items: center;
     width: var(--album-art-size);
-    position: relative;
   }
 
   &__track {

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -15,9 +15,7 @@ const { progressPercentage } = storeToRefs(spotifyStore)
 
 <style lang="scss" progress>
 .progress-container {
-  position: absolute;
-  bottom: 0;
-  left: 0;
+  position: relative;
   width: 100%;
   border-radius: 5px;
   overflow: hidden;

--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -64,7 +64,6 @@ const { lineNumber, lineNumberArtist, hideControls } = storeToRefs(appStore)
   &__cover {
     width: var(--album-art-size);
     max-width: 95vmin;
-    position: relative;
   }
 
   &__image {
@@ -80,7 +79,8 @@ const { lineNumber, lineNumberArtist, hideControls } = storeToRefs(appStore)
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    width: 38.02083333333333vw;
+    flex: 1;
+    min-width: 0;
   }
 
   &__details > div:first-child {
@@ -136,14 +136,13 @@ const { lineNumber, lineNumberArtist, hideControls } = storeToRefs(appStore)
 }
 
 .container {
-  display: grid;
-  gap: 5.729166666666666vw;
-  grid-template-columns: repeat(2, 1fr);
-  position: absolute;
-  top: 20.37037037037037vh;
-  left: 11.458333333333332vw;
-  width: 77.08333333333334vw;
-  height: 61.111111111111114vh;
+  display: flex;
+  gap: 3vw;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 5vh 5vw;
+  align-items: center;
 }
 
 .multiline-ellipsis {

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -47,6 +47,7 @@ export const useAppStore = defineStore(
       let textSize = ''
       let titleSize = ''
       let artistSize = ''
+
       if (value === 'none') {
         displayText = 'none'
         displayAlbumArt = 'inherit'


### PR DESCRIPTION
## Summary
- undo progress bar positioning changes and restore album art margins
- revert layout adjustments so album art sizing is independent of text style again

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6881bd212b4c832e903a3a6708915ab0