### PR TITLE
Improve keyboard shortcut overlay

### DIFF
--- a/src/components/KeyboardShortcuts.vue
+++ b/src/components/KeyboardShortcuts.vue
@@ -32,7 +32,8 @@ function close() {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(5px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -54,7 +55,7 @@ function close() {
 }
 .overlay-content kbd {
   background: #333;
-  padding: 0.2rem 0.4rem;
+  padding: 0.25rem 0.4rem;
   border-radius: 3px;
   margin-right: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- dim & blur screen behind keyboard shortcuts overlay
- tweak padding for keyboard shortcut chips

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6881c350ee78832e9063ad7035d513b1