### PR TITLE
Fix primary color initialization

### DIFF
--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -224,8 +224,6 @@ export async function setAppColours(settings: any, imageUrl: string) {
   document.documentElement.style.setProperty('--album-image', `url(${imageUrl})`)
   document.documentElement.style.setProperty('--controls-color', `#fff`)
   document.documentElement.style.setProperty('--color-text-primary', '#fff')
-  document.documentElement.style.setProperty('--primary-color', `#fff`)
-
   if (['match', 'match-dark'].includes(settings?.backgroundOption)) getMatchColors(blobUrl)
   else if (['contrast'].includes(settings?.backgroundOption)) getMatchContrastColors(blobUrl)
   else if (['spotlight'].includes(settings?.backgroundOption)) {


### PR DESCRIPTION
## Summary
- avoid setting `--primary-color` in `setAppColours`
- keep prior primary color until new album is processed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881c35ff874832eaafb2b3b9ba42cd7