### PR TITLE
Fix album art layout

### DIFF
--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -68,6 +68,8 @@ const { lineNumber, lineNumberArtist, hideControls } = storeToRefs(appStore)
     margin-top: 10%;
     margin-bottom: 10%;
     align-self: stretch;
+    /* Nudge album art slightly left */
+    transform: translateX(-3vw);
   }
 
   &__image {
@@ -86,6 +88,8 @@ const { lineNumber, lineNumberArtist, hideControls } = storeToRefs(appStore)
     justify-content: space-between;
     flex: 1;
     min-width: 0;
+    /* Shift text and controls slightly right */
+    transform: translateX(3vw);
   }
 
   &__details > div:first-child {

--- a/src/styles/global/variables.scss
+++ b/src/styles/global/variables.scss
@@ -28,5 +28,6 @@
   --font-weight-heading: 900;
 
   --body-line-height: 1.1;
-  --album-art-size: clamp(150px, 40vmin, 640px);
+  /* Slightly smaller album art */
+  --album-art-size: clamp(150px, 32vmin, 640px);
 }


### PR DESCRIPTION
## Summary
- reduce album art size via CSS variable
- offset album art to the left and track details to the right

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68830b733320832e93afb89589a549e7