### PR TITLE
Adjust player layout spacing

### DIFF
--- a/src/components/PlayerControls.vue
+++ b/src/components/PlayerControls.vue
@@ -154,7 +154,7 @@ const { isPlaying, shuffleState, repeatState } = storeToRefs(spotifyStore);
   left: -2.3%;
   width: 27.083333333333332vw;
   height: 8.148148148148149vh;
-  //gap: 1.3vw;
+  column-gap: 1.25%;
   //max-width: 100%;
 }
 

--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -23,6 +23,7 @@ const { progressPercentage } = storeToRefs(spotifyStore)
   margin-left: auto;
   margin-right: auto;
   border-radius: 2px;
+  z-index: 2;
 }
 
 .progress-container::before {

--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -92,8 +92,8 @@ watch([trackName, artistName, lineNumber, lineNumberArtist, hideControls], () =>
   &__cover {
     grid-row: 1 / span 3;
     max-width: 95vmin;
-    margin-top: 10%;
-    margin-bottom: 10%;
+    margin-top: auto;
+    margin-bottom: auto;
     /* Nudge album art slightly left */
     transform: translateX(-3vw);
     display: flex;
@@ -172,7 +172,7 @@ watch([trackName, artistName, lineNumber, lineNumberArtist, hideControls], () =>
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-rows: min-content 1fr min-content;
-  column-gap: 5%;
+  column-gap: 2.5%;
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;

--- a/src/components/TextOnlyPlayer.vue
+++ b/src/components/TextOnlyPlayer.vue
@@ -196,6 +196,6 @@ const { hideControls, showSettingButton } = storeToRefs(appStore);
 </style>
 <style>
 .controls {
-  gap: 1.5vw;
+  gap: 1.25%;
 }
 </style>

--- a/src/styles/global/variables.scss
+++ b/src/styles/global/variables.scss
@@ -28,6 +28,6 @@
   --font-weight-heading: 900;
 
   --body-line-height: 1.1;
-  /* Slightly smaller album art */
-  --album-art-size: clamp(150px, 32vmin, 640px);
+  /* Album art should never be smaller than 640px */
+  --album-art-size: max(640px, 32vmin);
 }


### PR DESCRIPTION
## Summary
- enforce a larger minimum album art size
- vertically center album art in `RegularPlayer`
- reduce gap between album art and track text
- adjust playback control spacing
- ensure progress bar has z-index so it shows on top

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68831567a638832eb762763085ac18a2