### PR TITLE
Adjust player layout and progress bar styling

### DIFF
--- a/src/components/ProgressBar.vue
+++ b/src/components/ProgressBar.vue
@@ -13,13 +13,13 @@ const spotifyStore = useSpotifyStore()
 const { progressPercentage } = storeToRefs(spotifyStore)
 </script>
 
-<style lang="scss" progress>
+<style lang="scss" scoped>
 .progress-container {
   position: relative;
   width: 100%;
   border-radius: 5px;
   overflow: hidden;
-  height: 0.5vh;
+  height: 1vh;
   margin-left: auto;
   margin-right: auto;
   border-radius: 2px;

--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -94,8 +94,6 @@ watch([trackName, artistName, lineNumber, lineNumberArtist, hideControls], () =>
     max-width: 95vmin;
     margin-top: auto;
     margin-bottom: auto;
-    /* Nudge album art slightly left */
-    transform: translateX(-3vw);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -118,8 +116,6 @@ watch([trackName, artistName, lineNumber, lineNumberArtist, hideControls], () =>
     justify-content: space-between;
     flex: 1;
     min-width: 0;
-    /* Shift text and controls slightly right */
-    transform: translateX(3vw);
   }
 
   &__details > div:first-child {
@@ -128,6 +124,7 @@ watch([trackName, artistName, lineNumber, lineNumberArtist, hideControls], () =>
   }
 
   &__controls {
+    margin-top: 1.25vw;
     margin-bottom: 15%;
     width: 80%;
     position: relative;
@@ -177,7 +174,8 @@ watch([trackName, artistName, lineNumber, lineNumberArtist, hideControls], () =>
   max-width: 1200px;
   margin: 0 auto;
   padding: 5vh 5vw;
-  align-items: stretch;
+  align-items: center;
+  justify-items: center;
 }
 
 .multiline-ellipsis {


### PR DESCRIPTION
## Summary
- center player grid items
- remove leftover transform offsets
- show progress bar using scoped style and larger height
- add margin between artists and controls

## Testing
- `npm run format`
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_6883198b83d8832ea251941606af6eee