### PR TITLE
Limit album art height

### DIFF
--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -55,7 +55,9 @@ function updateAlbumArtSize() {
   nextTick(() => {
     const textHeight = textRef.value?.offsetHeight || 0
     const controlsHeight = controlsRef.value?.offsetHeight || 0
-    albumArtSize.value = textHeight + controlsHeight
+    const calculatedSize = textHeight + controlsHeight
+    const maxSize = window.innerHeight * 2 / 3
+    albumArtSize.value = Math.min(calculatedSize, maxSize)
   })
 }
 

--- a/src/styles/global/variables.scss
+++ b/src/styles/global/variables.scss
@@ -28,6 +28,6 @@
   --font-weight-heading: 900;
 
   --body-line-height: 1.1;
-  /* Album art should never be smaller than 640px */
-  --album-art-size: max(640px, 32vmin);
+  /* Album art should never be smaller than 640px and no larger than 2/3 of the viewport height */
+  --album-art-size: min(max(640px, 32vmin), 66.67vh);
 }


### PR DESCRIPTION
## Summary
- cap the `--album-art-size` CSS variable at 2/3 of the viewport height
- restrict regular player album art size to 2/3 of the viewport

## Testing
- `npm run type-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688322628a14832e8a573b67c7c15320