### PR TITLE
Add alt attributes to images

### DIFF
--- a/src/components/AlbumArt.vue
+++ b/src/components/AlbumArt.vue
@@ -7,6 +7,7 @@
         :style="`margin-bottom: ${
           miscellaneousOption.includes('show-progress-bar') ? '15px' : '0px'
         }`"
+        alt="Album Art"
       />
     </transition>
   </div>

--- a/src/components/RecentScreen.vue
+++ b/src/components/RecentScreen.vue
@@ -6,7 +6,7 @@
     <div class="tracks-container">
       <div>
         <h1>Favorites</h1>
-        <img src="@/assets/liked-songs.png" @click="playSaved" />
+        <img src="@/assets/liked-songs.png" @click="playSaved" alt="Liked songs" />
         <h2>Liked Songs</h2>
       </div>
       <div>
@@ -15,7 +15,7 @@
           <Splide :options="options" aria-label="My Favorite Images">
             <SplideSlide v-for="item in recentlyPlayedTracksNoDuplicates" :key="item.track.id">
               <div class="carousel-item" @click="playRecent(item)">
-                <img :src="item.track.album.images[0].url" />
+                <img :src="item.track.album.images[0].url" :alt="`${item.track.name} album art`" />
                 <h2>
                   <TextClamp :text="item.track.name" :max-lines="1" />
                 </h2>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -2,7 +2,7 @@
   <div id="app">
     <NowPlaying />
     <div v-show="showSettingButton" class="settings-container fade-slide-up" ref="settingButton" @click="openSettings">
-      <img src="@/assets/SettingIcon.svg?url" />
+      <img src="@/assets/SettingIcon.svg?url" alt="Settings" />
       <span>SETTINGS</span>
     </div>
   </div>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,12 +1,12 @@
 <template>
   <div id="setting-screen">
     <div class="closeIconContainer">
-      <img src="@/assets/CloseIcon.svg?url" @click="router.back()" />
+      <img src="@/assets/CloseIcon.svg?url" @click="router.back()" alt="Close" />
     </div>
     <div class="container">
       <div class="img-container">
         <div>
-          <img src="@/assets/text-logo.svg?url" class="logo" />
+          <img src="@/assets/text-logo.svg?url" class="logo" alt="PlayThing Logo" />
           <div class="seperator"></div>
         </div>
       </div>
@@ -21,8 +21,7 @@
               @click="setNothingPlaying(option.value)"
             >
               <span v-if="nothingPlayingOption.includes(option.value)"
-                ><img src="@/assets/CaretIcon.svg?url"
-              /></span>
+                ><img src="@/assets/CaretIcon.svg?url" alt="Selected" /></span>
               <span
                 v-if="option.value != 'regular-clock'"
                 :class="option.value === nothingPlayingOption ? 'active' : ''"
@@ -54,8 +53,7 @@
               @click="setBackgroundOption(option.value)"
             >
               <span v-if="option.value === backgroundOption"
-                ><img src="@/assets/CaretIcon.svg?url"
-              /></span>
+                ><img src="@/assets/CaretIcon.svg?url" alt="Selected" /></span>
               <span :class="option.value === backgroundOption ? 'active' : ''">{{
                 option.title
               }}</span>
@@ -71,8 +69,7 @@
               @click="setTextOption(option.value)"
             >
               <span v-if="option.value === textOption"
-                ><img src="@/assets/CaretIcon.svg?url"
-              /></span>
+                ><img src="@/assets/CaretIcon.svg?url" alt="Selected" /></span>
               <span :class="option.value === textOption ? 'active' : ''">{{ option.title }}</span>
             </li>
           </ul>
@@ -86,8 +83,7 @@
               @click="setMiscellaneousOption(option.value)"
             >
               <span v-if="miscellaneousOption.includes(option.value)"
-                ><img src="@/assets/CaretIcon.svg?url"
-              /></span>
+                ><img src="@/assets/CaretIcon.svg?url" alt="Selected" /></span>
               <span :class="miscellaneousOption.includes(option.value) ? 'active' : ''">{{
                 option.title
               }}</span>


### PR DESCRIPTION
## Summary
- add meaningful `alt` text on `<img>` tags
- run linter and type-check

## Testing
- `npm run type-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688325c7973c832eb1632da927688f17