### PR TITLE
Remove !important from styles

### DIFF
--- a/src/components/TextOnlyPlayer.vue
+++ b/src/components/TextOnlyPlayer.vue
@@ -158,8 +158,8 @@ const { hideControls, showSettingButton } = storeToRefs(appStore);
 }
 
 
-.bottom-controls .controls {
-  left: 0 !important;
+.bottom-controls :deep(.controls) {
+  left: 0;
 }
 
 /*.bottom-progress {

--- a/src/components/TwelveHourClock.vue
+++ b/src/components/TwelveHourClock.vue
@@ -60,8 +60,8 @@ onUnmounted(() => {
   text-align: start;
 }
 
-.container span:first-child {
-  text-align: end !important;
+.time-text:first-child {
+  text-align: end;
 }
 
 .colon {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -27,9 +27,9 @@ function openSettings() {
 <style lang="scss" scoped>
 #app {
   position: relative;
-  width: 100vw !important;
-  height: 100vh !important;
-  overflow-x: hidden !important;
+  width: 100vw;
+  height: 100vh;
+  overflow-x: hidden;
   overflow-y: hidden;
 }
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -321,9 +321,9 @@ h3 {
   }
 }
 
-.colorless-active {
+.setting-container li span.colorless-active {
   color: #5c5c5c;
-  margin-left: 5px !important;
+  margin-left: 5px;
 }
 
 .setting-container li span.active {


### PR DESCRIPTION
## Summary
- tweak HomeView layout styles
- style SettingsView clock margin without `!important`
- remove `!important` from TwelveHourClock alignment
- target PlayerControls in TextOnlyPlayer without `!important`

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_688325bc18e8832ebe5816f14692672d