### PR TITLE
Fix layout spacing and progress bar placement

### DIFF
--- a/src/components/AlbumArt.vue
+++ b/src/components/AlbumArt.vue
@@ -35,9 +35,10 @@ const { miscellaneousOption } = storeToRefs(settingsStore)
   }
 
   &__image {
-    //box-shadow: 1px 1px 16px -2px rgba(0, 0, 0, 0.3);
-    height: auto;
+    position: relative;
     width: 100%;
+    height: 100%;
+    //box-shadow: 1px 1px 16px -2px rgba(0, 0, 0, 0.3);
     max-width: var(--album-art-size);
     aspect-ratio: 1;
     border-radius: 10px;

--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -171,11 +171,11 @@ watch([trackName, artistName, lineNumber, lineNumberArtist, hideControls], () =>
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-rows: min-content 1fr min-content;
-  column-gap: 2.5%;
+  column-gap: 2.5vmin;
   width: 100%;
   max-width: 1200px;
-  margin: 0 auto;
-  padding: 5vh 5vw;
+  margin: auto;
+  padding: 5vmin;
   align-items: center;
   justify-items: center;
 }


### PR DESCRIPTION
## Summary
- center the player container and use vmin spacing
- ensure album art container has size so progress bar shows below

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68832967de6c832e82605e261ea71e44