### PR TITLE
Fix invalid Spotify scope

### DIFF
--- a/src/stores/spotify.ts
+++ b/src/stores/spotify.ts
@@ -11,7 +11,6 @@ const scopes = [
   'user-read-recently-played',
   'user-library-read',
   'user-read-private',
-  'user-read-birthdate',
   'user-read-email'
 ]
 


### PR DESCRIPTION
## Summary
- remove `user-read-birthdate` from the OAuth scope list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885e6b0a8f4832eb939117a81beb406