### PR TITLE
Increase album art size and spacing

### DIFF
--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -145,7 +145,7 @@ const { lineNumber, lineNumberArtist, hideControls } = storeToRefs(appStore)
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 2.5vmin;
+  gap: 5vmin;
   width: 100%;
   max-width: 1024px;
   margin-left: auto;

--- a/src/styles/global/variables.scss
+++ b/src/styles/global/variables.scss
@@ -29,5 +29,5 @@
 
   --body-line-height: 1.1;
   /* Album art should never be smaller than 640px and no larger than 2/3 of the viewport height */
-  --album-art-size: min(max(640px, 32vmin), 66.67vh);
+  --album-art-size: min(max(768px, 38.4vmin), 80vh);
 }


### PR DESCRIPTION
## Summary
- make album artwork bigger
- double the gap between the artwork and text

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68868e621d8c832eb53d27b81f298d34