### PR TITLE
fix: remove invalid Spotify scope causing OAuth error

### DIFF
--- a/src/stores/spotify.ts
+++ b/src/stores/spotify.ts
@@ -11,7 +11,6 @@ const scopes = [
   'user-read-recently-played',
   'user-library-read',
   'user-read-private',
-  'user-read-birthdate',
   'user-read-email'
 ]
 


### PR DESCRIPTION
Fixes OAuth error by removing invalid Spotify scope.