### PR TITLE
fix: limit album art height and center vertically

### DIFF
--- a/src/components/RegularPlayer.vue
+++ b/src/components/RegularPlayer.vue
@@ -55,7 +55,9 @@ function updateAlbumArtSize() {
   nextTick(() => {
     const textHeight = textRef.value?.offsetHeight || 0
     const controlsHeight = controlsRef.value?.offsetHeight || 0
-    albumArtSize.value = textHeight + controlsHeight
+    const calculatedSize = textHeight + controlsHeight
+    const maxSize = window.innerHeight * 2 / 3
+    albumArtSize.value = Math.min(calculatedSize, maxSize)
   })
 }
 

--- a/src/styles/global/variables.scss
+++ b/src/styles/global/variables.scss
@@ -28,6 +28,6 @@
   --font-weight-heading: 900;
 
   --body-line-height: 1.1;
-  /* Album art should never be smaller than 640px */
-  --album-art-size: max(640px, 32vmin);
+  /* Album art should never be smaller than 640px and no larger than 2/3 of the viewport height */
+  --album-art-size: min(max(640px, 32vmin), 66.67vh);
 }


### PR DESCRIPTION
Restricts album art size and centers it vertically in the player.