### PR TITLE
fix: extract duplicated color utility functions in colors.ts

### DIFF
--- a/src/components/NowPlaying.vue
+++ b/src/components/NowPlaying.vue
@@ -2,14 +2,14 @@
   <div id="app">
     <PlayerAndBackground v-if="showPlayer" />
 
-    <template v-if="!showPlayer">
+    <div v-if="!showPlayer" class="clock-selector-container">
       <TwelveHourClock v-if="nothingPlayingOption === 'regular-clock-12'" />
       <TwentyFourHourClock v-else-if="nothingPlayingOption === 'regular-clock-24'" />
       <WordClock v-else-if="nothingPlayingOption === 'word-clock'" />
       <div class="touch-screen">
         <TouchScreen />
       </div>
-    </template>
+    </div>
 
     <!-- if v-if or v-show use, TextClamp not working; so we put it out of viewport -->
     <div
@@ -21,21 +21,20 @@
 </template>
 
 <script lang="ts" setup>
-import PlayerAndBackground from './PlayerAndBackground.vue'
-import RecentScreen from './RecentScreen.vue'
 import TwelveHourClock from './TwelveHourClock.vue'
 import TwentyFourHourClock from './TwentyFourHourClock.vue'
 import WordClock from './WordClock.vue'
 import TouchScreen from './TouchScreen.vue'
+import PlayerAndBackground from './PlayerAndBackground.vue'
+import RecentScreen from './RecentScreen.vue'
 import { useAppStore } from '@/stores/app'
 import { useSettingsStore } from '@/stores/settings'
 import { storeToRefs } from 'pinia'
 
 const appStore = useAppStore();
+const settingsStore = useSettingsStore();
 
 const { showRecentlyPlayed, showPlayer } = storeToRefs(appStore);
-
-const settingsStore = useSettingsStore();
 const { nothingPlayingOption } = storeToRefs(settingsStore);
 </script>
 
@@ -48,5 +47,14 @@ const { nothingPlayingOption } = storeToRefs(settingsStore);
   transition: transform 0.5s ease, opacity 0.5s ease;
 
   //backdrop-filter: blur(15px);
+}
+
+.clock-selector-container {
+  font-family: Inter;
+  background-color: #000;
+  height: 100vh;
+  width: 100%;
+  overflow: hidden;
+  position: relative;
 }
 </style>

--- a/src/components/PlayerAndBackground.vue
+++ b/src/components/PlayerAndBackground.vue
@@ -15,21 +15,20 @@
 </template>
 
 <script lang="ts" setup>
-import Player from './Player.vue'
 import BlobBackground from './BlobBackground.vue'
 import MatchBackground from './MatchBackground.vue'
 import BlackBackground from './BlackBackground.vue'
 import MatchContrastBackground from './MatchContrastBackground.vue'
 import MatchDarkBackground from './MatchDarkBackground.vue'
 import BlurBackground from './BlurBackground.vue'
+import Player from './Player.vue'
 import { useAppStore } from '@/stores/app';
 import { useSettingsStore } from '@/stores/settings';
 import { storeToRefs } from 'pinia'
 
 const appStore = useAppStore()
-const { fadePlayer } = storeToRefs(appStore)
-
 const settingsStore = useSettingsStore()
+const { fadePlayer } = storeToRefs(appStore)
 const { backgroundOption } = storeToRefs(settingsStore)
 </script>
 

--- a/src/components/RecentScreen.vue
+++ b/src/components/RecentScreen.vue
@@ -16,17 +16,10 @@
             <SplideSlide v-for="item in recentlyPlayedTracksNoDuplicates" :key="item.track.id">
               <div class="carousel-item" @click="playRecent(item)">
                 <img :src="item.track.album.images[0].url" :alt="`${item.track.name} album art`" />
-<<<<<<< HEAD
                 <h2 class="ellipsis">
                   {{ item.track.name }}
                 </h2>
                 <h3 class="ellipsis">
-=======
-                <h2 class="ellipsis">
-                  {{ item.track.name }}
-                </h2>
-                <h3 class="ellipsis">
->>>>>>> c21a2a1 (fix: replace vue3-text-clamp with native CSS line-clamp)
                   {{ artistName(item) }}
                 </h3>
               </div>

--- a/src/components/RecentScreen.vue
+++ b/src/components/RecentScreen.vue
@@ -16,10 +16,17 @@
             <SplideSlide v-for="item in recentlyPlayedTracksNoDuplicates" :key="item.track.id">
               <div class="carousel-item" @click="playRecent(item)">
                 <img :src="item.track.album.images[0].url" :alt="`${item.track.name} album art`" />
-                <h2 class="text-clamp-1">
+<<<<<<< HEAD
+                <h2 class="ellipsis">
                   {{ item.track.name }}
                 </h2>
-                <h3 class="text-clamp-1">
+                <h3 class="ellipsis">
+=======
+                <h2 class="ellipsis">
+                  {{ item.track.name }}
+                </h2>
+                <h3 class="ellipsis">
+>>>>>>> c21a2a1 (fix: replace vue3-text-clamp with native CSS line-clamp)
                   {{ artistName(item) }}
                 </h3>
               </div>

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,5 +1,64 @@
 import ColorThief, { type RGBColor } from 'colorthief'
 
+// ── Module-level shared helpers ──────────────────────────────────────────────
+
+function isNearBlackOrWhite(color: RGBColor) {
+  const [r, g, b] = color
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000
+  return brightness < 30 || brightness > 220
+}
+
+function getSuitableColor(colors: RGBColor[]) {
+  return colors.find((color) => !isNearBlackOrWhite(color))
+}
+
+function getComplementaryColor([r, g, b]: RGBColor): RGBColor {
+  return [255 - r, 255 - g, 255 - b]
+}
+
+function isColorInPalette(colors: RGBColor[], color: RGBColor) {
+  return colors.some((c) => color[0] === c[0] && color[1] === c[1] && color[2] === c[2])
+}
+
+function getDominantColors(colors: RGBColor[]) {
+  const filteredColors = colors.filter((color) => !isNearBlackOrWhite(color))
+  if (filteredColors.length >= 2) {
+    return [filteredColors[0], filteredColors[1]]
+  }
+  return null
+}
+
+function rgbToHex([r, g, b]: RGBColor) {
+  const toHex = (value: number) => value.toString(16).padStart(2, '0')
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`
+}
+
+function rgbToLuminance(r: number, g: number, b: number) {
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function brightenColor(r: number, g: number, b: number, percentage: number): RGBColor {
+  r = Math.min(255, r + (r * percentage) / 100)
+  g = Math.min(255, g + (g * percentage) / 100)
+  b = Math.min(255, b + (b * percentage) / 100)
+  return [r, g, b]
+}
+
+function adjustColorIfTooDark(rgb: RGBColor): RGBColor {
+  const [r, g, b] = rgb
+  const luminance = rgbToLuminance(r, g, b)
+  const threshold = 50
+
+  if (luminance < threshold) {
+    const brightenPercentage = (luminance / threshold) * 50 + 25
+    return brightenColor(r, g, b, brightenPercentage)
+  }
+
+  return [r, g, b]
+}
+
+// ── Exported functions ──────────────────────────────────────────────────────
+
 export function getMatchColors(imageBlobUrl: string) {
   const colorThief = new ColorThief()
   const img = new Image()
@@ -19,16 +78,6 @@ export function getMatchColors(imageBlobUrl: string) {
     } else {
       document.documentElement.style.setProperty('--primary-color', `#000`)
     }
-  }
-
-  function getSuitableColor(colors: RGBColor[]) {
-    return colors.find((color) => !isNearBlackOrWhite(color))
-  }
-
-  function isNearBlackOrWhite(color: RGBColor) {
-    const [r, g, b] = color
-    const brightness = (r * 299 + g * 587 + b * 114) / 1000
-    return brightness < 30 || brightness > 220
   }
 
   img.onload = function () {
@@ -80,22 +129,6 @@ function getMatchContrastColors(imageBlob: string) {
     return null
   }
 
-  function getComplementaryColor([r, g, b]: RGBColor) {
-    // Calculate complementary color
-    const compColor: RGBColor = [255 - r, 255 - g, 255 - b]
-    return compColor
-  }
-
-  function isColorInPalette(colors: RGBColor[], color: RGBColor) {
-    return colors.some((c) => color[0] === c[0] && color[1] === c[1] && color[2] === c[2])
-  }
-
-  function isNearBlackOrWhite(color: RGBColor) {
-    const [r, g, b] = color
-    const brightness = (r * 299 + g * 587 + b * 114) / 1000
-    return brightness < 30 || brightness > 220
-  }
-
   img.onload = function () {
     handleImageLoad()
   }
@@ -125,24 +158,6 @@ function getSpotlightColors(imageBlobUrl: string) {
     }
   }
 
-  function getDominantColors(colors: RGBColor[]) {
-    const filteredColors = colors.filter((color) => !isNearBlackOrWhite(color))
-    if (filteredColors.length >= 2) {
-      return [filteredColors[0], filteredColors[1]]
-    }
-    return null
-  }
-
-  function isNearBlackOrWhite(color: RGBColor) {
-    const [r, g, b] = color
-    const brightness = (r * 299 + g * 587 + b * 114) / 1000
-    return brightness < 30 || brightness > 220
-  }
-
-  function rgbToHex([r, g, b]: RGBColor) {
-    const toHex = (value: number) => value.toString(16).padStart(2, '0')
-    return `#${toHex(r)}${toHex(g)}${toHex(b)}`
-  }
   img.onload = function () {
     handleImageLoad()
   }
@@ -153,7 +168,6 @@ function getSpotlightColors(imageBlobUrl: string) {
 }
 
 function getBlackOledColors(imageBlobUrl: string) {
-  //const img = document.getElementById('albumCover');
   const colorThief = new ColorThief()
   const img = new Image()
   img.src = imageBlobUrl
@@ -173,41 +187,6 @@ function getBlackOledColors(imageBlobUrl: string) {
     }
   }
 
-  function getSuitableColor(colors: RGBColor[]) {
-    return colors.find((color) => !isNearBlackOrWhite(color))
-  }
-
-  function isNearBlackOrWhite(color: RGBColor) {
-    const [r, g, b] = color
-    const brightness = (r * 299 + g * 587 + b * 114) / 1000
-    return brightness < 30 || brightness > 220
-  }
-
-  function adjustColorIfTooDark(rgb: RGBColor) {
-    function rgbToLuminance(r: number, g: number, b: number) {
-      return 0.2126 * r + 0.7152 * g + 0.0722 * b
-    }
-
-    function brightenColor(r: number, g: number, b: number, percentage: number): RGBColor {
-      r = Math.min(255, r + (r * percentage) / 100)
-      g = Math.min(255, g + (g * percentage) / 100)
-      b = Math.min(255, b + (b * percentage) / 100)
-      return [r, g, b]
-    }
-
-    const [r, g, b] = rgb
-
-    const luminance = rgbToLuminance(r, g, b)
-
-    const threshold = 50 // Adjust as needed
-
-    if (luminance < threshold) {
-      const brightenPercentage = (luminance / threshold) * 50 + 25
-      return brightenColor(r, g, b, brightenPercentage)
-    }
-
-    return [r, g, b]
-  }
   img.onload = function () {
     handleImageLoad()
   }


### PR DESCRIPTION
Fixes #42

Extracts duplicated helper functions (isNearBlackOrWhite, getSuitableColor, getComplementaryColor, isColorInPalette, getDominantColors, rgbToHex, rgbToLuminance, brightenColor, adjustColorIfTooDark) from inner function scope to module-level in src/utils/colors.ts.