### PR TITLE
fix: replace vue3-text-clamp with CSS -webkit-line-clamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "simplex-noise": "^4.0.2",
     "vue": "^3.4.29",
     "vue-router": "^4.3.3",
-    "vue3-text-clamp": "^0.1.2",
     "vue3-touch-events": "^4.1.8"
   },
   "devDependencies": {

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -6,11 +6,11 @@
     <!-- Text-only layout (TextOnlyPlayer) -->
     <template v-if="isTextOnly">
       <div class="top-details">
-        <h1 class="now-playing__track">
-          <TextClamp :text="trackName" :max-lines="2" autoresize />
+        <h1 class="now-playing__track text-clamp-2">
+          {{ trackName }}
         </h1>
-        <h2 class="now-playing__artists">
-          <TextClamp :text="artistName" :max-lines="2" autoresize />
+        <h2 class="now-playing__artists text-clamp-2">
+          {{ artistName }}
         </h2>
       </div>
 
@@ -58,11 +58,11 @@
           :style="`justify-content: ${hideControls ? 'center' : 'space-between'}`"
         >
           <div>
-            <h1 class="now-playing__track">
-              <TextClamp :text="trackName" :max-lines="lineNumber" />
+            <h1 class="now-playing__track text-clamp-2">
+              {{ trackName }}
             </h1>
-            <h2 class="now-playing__artists">
-              <TextClamp :text="artistName" :max-lines="lineNumberArtist" />
+            <h2 class="now-playing__artists text-clamp-2">
+              {{ artistName }}
             </h2>
           </div>
           <div class="now-playing__controls" v-show="!hideControls">
@@ -82,7 +82,6 @@
 <script lang="ts" setup>
 import ProgressBar from '@/components/ProgressBar.vue'
 import PlayerControls from '@/components/PlayerControls.vue'
-import TextClamp from 'vue3-text-clamp'
 import { useSpotifyStore } from '@/stores/spotify'
 import { storeToRefs } from 'pinia'
 import { useSettingsStore } from '@/stores/settings'
@@ -328,6 +327,13 @@ const isNoText = computed(() => textOption.value === 'none')
   text-overflow: ellipsis;
   width: 100%;
   display: block;
+}
+
+.text-clamp-2 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 }
 </style>
 

--- a/src/components/RecentScreen.vue
+++ b/src/components/RecentScreen.vue
@@ -16,11 +16,11 @@
             <SplideSlide v-for="item in recentlyPlayedTracksNoDuplicates" :key="item.track.id">
               <div class="carousel-item" @click="playRecent(item)">
                 <img :src="item.track.album.images[0].url" :alt="`${item.track.name} album art`" />
-                <h2>
-                  <TextClamp :text="item.track.name" :max-lines="1" />
+                <h2 class="text-clamp-1">
+                  {{ item.track.name }}
                 </h2>
-                <h3>
-                  <TextClamp :text="artistName(item)" :max-lines="1" />
+                <h3 class="text-clamp-1">
+                  {{ artistName(item) }}
                 </h3>
               </div>
             </SplideSlide>
@@ -38,7 +38,6 @@
 
 <script lang="ts" setup>
 import TouchScreen from './TouchScreen.vue'
-import TextClamp from 'vue3-text-clamp';
 // @ts-ignore
 import { Splide, SplideSlide } from '@splidejs/vue-splide';
 import '@splidejs/vue-splide/css';
@@ -259,5 +258,19 @@ function artistName(track: typeof recentlyPlayedTracks.value[number]) {
   text-overflow: ellipsis;
   width: 100%;
   display: block;
+}
+
+.text-clamp-1 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+}
+
+.text-clamp-2 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 }
 </style>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -112,7 +112,7 @@
           <p>
             Open Source Libraries in use: @georgedoescode/spline, @spotify/web-api-ts-sdk,
             colorthief, pinia, pinia-plugin-persistedstate, simplex-noise, vue-router, vue-splide,
-            vue3-text-clamp, vue3-touch-events, vueJS.
+            vue3-touch-events, vueJS.
           </p>
         </section>
       </div>


### PR DESCRIPTION
Fixes #46

Replaces vue3-text-clamp dependency with native CSS -webkit-line-clamp utility classes in Player.vue, RecentScreen.vue, and removes the unused dependency.