### PR TITLE
fix: add defineOptions name to Player.vue, remove unused lineNumber/lineNumberArtist

### DIFF
--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -88,7 +88,11 @@ import { useSettingsStore } from '@/stores/settings'
 import { useAppStore } from '@/stores/app'
 import AlbumArt from './AlbumArt.vue'
 import TouchScreen from './TouchScreen.vue'
-import { computed } from 'vue'
+import { computed, defineOptions } from 'vue'
+
+defineOptions({
+  name: 'NowPlayingPlayer'
+})
 
 const settingsStore = useSettingsStore()
 const spotifyStore = useSpotifyStore()
@@ -96,7 +100,7 @@ const appStore = useAppStore()
 
 const { textOption, miscellaneousOption } = storeToRefs(settingsStore)
 const { trackName, artistName } = storeToRefs(spotifyStore)
-const { lineNumber, lineNumberArtist, hideControls, showSettingButton } = storeToRefs(appStore)
+const { hideControls, showSettingButton } = storeToRefs(appStore)
 
 const isTextOnly = computed(() => textOption.value === 'text-only')
 const isNoText = computed(() => textOption.value === 'none')


### PR DESCRIPTION
Realigns with Vue 3 component-naming best practice (defineOptions name) and removes now-dead lineNumber/lineNumberArtist refs destructured in Player.vue but never consumed.

Follows on the recent dead-code-removal PRs (#58, #72).

- [x] `npm run build` passes (157 modules, type-check clean)
- [x] `npm run lint` clean

NOTE: authored by @indigokarasu; per dispatcher rules, no KODA self-review dispatched. Awaiting maintainer review — do not merge until reviewed.